### PR TITLE
Update post install message

### DIFF
--- a/seafile_ubuntu
+++ b/seafile_ubuntu
@@ -528,13 +528,16 @@ cat > ${TOPDIR}/aio_seafile-server.log<<EOF
   Next you should manually complete the following steps
   -----------------------------------------------------------------
 
-  1) Run seafile-server-change-address to add your Seafile servers DNS name
-
+  1) Log in to Seafile and configure your server domain via the system 
+     admin area if applicable.
+  
   2) If this server is behind a firewall, you need to ensure that
      tcp port 80 is open.
 
   3) Seahub tries to send emails via the local server. Install and
-     configure Postfix for this to work.
+     configure Postfix for this to work or 
+     check https://manual.seafile.com/config/sending_email.html
+     for instructions on how to use an existing email account via SMTP.
 
 
 


### PR DESCRIPTION
Having recently completed Seafile setup, I would propose these updates, as the current text was slightly confusing to me (`seafile_server_change_address`) or could be solved better in my case (SMTP - better choice for me despite login credentials on server).


1) Removed reference to `seafile_server_change_address`, as that is apparently not required anymore.
2) Added reference to email sending via SMTP on Seafile website.