### PR TITLE
Immediately start memcached in Centos

### DIFF
--- a/seafile_centos
+++ b/seafile_centos
@@ -183,6 +183,11 @@ pip install Pillow==4.3.0
 systemctl enable memcached
 
 # -------------------------------------------
+# Start memcached
+# -------------------------------------------
+systemctl start memcached
+
+# -------------------------------------------
 # Install nginx
 # -------------------------------------------
 yum install nginx -y


### PR DESCRIPTION
Memcached is not started after installation. This change immediately starts it, so it is running at the end of installation.

I cannot check how memcached behaves in Ubuntu, so this pr is only for centos