### PR TITLE
Don't fail on different nginx folder structure

### DIFF
--- a/seafile-7.1_ubuntu
+++ b/seafile-7.1_ubuntu
@@ -166,7 +166,8 @@ service memcached start
 # Setup Nginx
 # -------------------------------------------
 
-rm /etc/nginx/sites-enabled/*
+rm -f /etc/nginx/sites-enabled/*
+mkdir -p /etc/nginx/sites-available
 
 cat > /etc/nginx/sites-available/seafile.conf << EOF
 log_format seafileformat '\$http_x_forwarded_for \$remote_addr [\$time_local] "\$request" \$status \$body_bytes_sent "\$http_referer" "\$http_user_agent" \$upstream_response_time';


### PR DESCRIPTION
This commit should make the script a bit more robust in case somebody a) has deleted `sites-available` (because it's a ridiculous concept and it's totally fine to just put the relevant config files directly in `sites-enabled`) or b) has no files in `sites-enabled` at the moment.


I would even argue just deleting all of people's configs is not great either but I guess you have a "only do this on a fresh host" disclaimer somewhere.